### PR TITLE
Add CompositeStepper

### DIFF
--- a/RxFlow/Stepper.swift
+++ b/RxFlow/Stepper.swift
@@ -30,8 +30,22 @@ public class OneStepper: Stepper {
     }
 }
 
+// A Stepper that combines multiple steppers
+final public class CompositeStepper: Stepper {
+    /// the Rx Obsersable that will emits new Steps
+    public private(set) var steps: Observable<Step>
+    
+    /// Initialise
+    ///
+    /// - Parameter steppers: Steppers will be observered
+    public init(steppers: [Stepper]) {
+        let allSteps = steppers.map { $0.steps }
+        steps = Observable.merge(allSteps)
+    }
+}
+
 /// a Stepper that triggers NoStep.
-class NoneStepper: OneStepper {
+final class NoneStepper: OneStepper {
     convenience init() {
         self.init(withSingleStep: NoStep())
     }


### PR DESCRIPTION
For some situation, I have both VM and ViewController act as Stepper. Navigation will be driven by business logic from VM and presentation logic from ViewController.  `CompositeStepper` will help to combine multiple Steppers.

This PR is WIP:

```Swift
let createScheduleViewController = CreateScheduleViewController()
let createScheduleViewModel = CreateScheduleViewModel(id: nil)
root.present(navi, animated: true, completion: nil)
return [Flowable(nextPresentable: createScheduleViewController, nextStepper: CompositeStepper(steppers: [createScheduleViewModel, createScheduleViewController]))]
```