### PR TITLE
rxswift: flatten FlowCoordinator subscriptions

### DIFF
--- a/RxFlow/Extensions/Rx+Pausable.swift
+++ b/RxFlow/Extensions/Rx+Pausable.swift
@@ -19,13 +19,64 @@ extension ObservableType {
     ///
     /// - Parameter pauser: The observable sequence used to pause the source observable sequence.
     /// - Returns: The observable sequence which is paused based upon the pauser observable sequence.
-    public func pausable<P: ObservableType> (_ pauser: P) -> Observable<E> where P.E == Bool {
+    public func pausable<P: ObservableType> (withPauser pauser: P) -> Observable<E> where P.E == Bool {
+
         return withLatestFrom(pauser) { element, paused in
-            (element, paused)
+            return (element, paused)
             }.filter { _, paused in
                 paused
             }.map { element, _ in
                 element
+        }
+    }
+
+    /// Pauses the elements of the source observable sequence based on the latest element from the second observable sequence.
+    /// The pause is available only after a certain count of events. Before the number of emitted events reaches that count
+    /// the Pauser will not be taken care of. When the Pauser is active, elements are ignored unless the second sequence
+    /// has most recently emitted `true`.
+    /// seealso: [pausable operator on reactivex.io](http://reactivex.io/documentation/operators/backpressure.html)
+    ///
+    /// - Parameter count: the number of events before considering the pauser parameter
+    /// - Parameter pauser: The observable sequence used to pause the source observable sequence.
+    /// - Returns: The observable sequence which is paused based upon the pauser observable sequence.
+    public func pausable<P: ObservableType> (afterCount count: Int, withPauser pauser: P) -> Observable<E> where P.E == Bool {
+
+        return Observable<E>.create { observer in
+
+            let lock = NSRecursiveLock()
+            var paused = true
+            var elementIndex = 0
+
+            let pauserDisposable = pauser.subscribe { event in
+                lock.lock(); defer { lock.unlock() }
+                switch event {
+                case .next(let resume):
+                    paused = !resume
+                case .completed:
+                    observer.onCompleted()
+                case .error(let error):
+                    observer.onError(error)
+                }
+            }
+
+            let disposable = self.subscribe { event in
+                lock.lock(); defer { lock.unlock() }
+                switch event {
+                case .next(let element):
+
+                    if (elementIndex < count) || !paused {
+                        elementIndex += 1
+                        observer.onNext(element)
+                    }
+
+                case .completed:
+                    observer.onCompleted()
+                case .error(let error):
+                    observer.onError(error)
+                }
+            }
+
+            return Disposables.create([disposable, pauserDisposable])
         }
     }
 }

--- a/RxFlow/Extensions/UIViewController+Rx.swift
+++ b/RxFlow/Extensions/UIViewController+Rx.swift
@@ -30,6 +30,9 @@ extension Reactive where Base: UIViewController {
     public var displayed: Observable<Bool> {
         let viewDidAppearObservable = self.sentMessage(#selector(Base.viewDidAppear)).map { _ in true }
         let viewWillDisappearObservable = self.sentMessage(#selector(Base.viewWillDisappear)).map { _ in false }
-        return Observable<Bool>.merge(viewDidAppearObservable, viewWillDisappearObservable)
+        // a UIViewController is at first not displayed
+        let initialState = Observable.just(false)
+        // futur calls to viewDidAppear and viewWillDisappear will chage the displayable state
+        return initialState.concat(Observable<Bool>.merge(viewDidAppearObservable, viewWillDisappearObservable))
     }
 }

--- a/RxFlow/Flow.swift
+++ b/RxFlow/Flow.swift
@@ -49,6 +49,7 @@ extension Flow {
 
 /// Utility functions to synchronize Flows readyness
 public class Flows {
+
     /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
     /// Once it is the case, the block is executed
     ///
@@ -68,6 +69,7 @@ public class Flows {
             block(roots)
         })
     }
+
     // swiftlint:disable function_parameter_count
     /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
     /// Once it is the case, the block is executed

--- a/RxFlow/Stepper.swift
+++ b/RxFlow/Stepper.swift
@@ -14,9 +14,6 @@ private var subjectContext: UInt8 = 0
 /// a Stepper has only one purpose is: emits Steps that correspond to specific navigation states.
 /// The Step changes lead to navigation actions in the context of a specific Flow
 public protocol Stepper: Synchronizable {
-
-    /// the Rx Obsersable that will emits new Steps
-    var steps: Observable<Step> { get }
 }
 
 /// A Simple Stepper that has one goal: emit a single Step once initialized
@@ -52,7 +49,7 @@ public extension Stepper {
     }
 
     /// the Rx Obsersable that will trigger new Steps
-    public var steps: Observable<Step> {
+    internal var steps: Observable<Step> {
         return self.step.asObservable()
     }
 }

--- a/RxFlowDemo/RxFlowDemo/Features/Dashboard/Wishlist/WishlistViewModel.swift
+++ b/RxFlowDemo/RxFlowDemo/Features/Dashboard/Wishlist/WishlistViewModel.swift
@@ -9,7 +9,7 @@
 import RxSwift
 import RxFlow
 
-class WishlistViewModel: Stepper {
+class WishlistViewModel: Stepper, HasDisposeBag {
 
     let movies: [MovieViewModel]
 

--- a/RxFlowDemo/RxFlowDemo/Flows/SettingsFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/SettingsFlow.swift
@@ -45,7 +45,7 @@ class SettingsFlow: Flow {
             settingsViewController.title = "Api Key"
             self.rootViewController.showDetailViewController(settingsViewController, sender: nil)
 
-            return [NextFlowItem(nextPresentable: navigationController, nextStepper: settingsListViewController),
+            return [NextFlowItem(nextPresentable: settingsListViewController, nextStepper: settingsListViewController),
                     NextFlowItem(nextPresentable: settingsViewController, nextStepper: settingsViewController)]
         case .apiKey:
             let settingsViewController = SettingsViewController.instantiate()

--- a/RxFlowDemo/RxFlowDemo/Flows/WishlistFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/WishlistFlow.swift
@@ -86,10 +86,18 @@ class WishlistFlow: Flow {
     }
 }
 
-class WishlistStepper: Stepper {
+class WishlistStepper: Stepper, HasDisposeBag {
 
     init() {
         self.step.accept(DemoStep.movieList)
+
+        // example of a periodic check of something to could lead to a global navigation action
+        // for instance it could be an Interval in which we check the session validity. In case of
+        // invalidity we could trigger a new Step (sessionInvalid for instance) that would lead to
+        // a login popup
+//        Observable<Int>.interval(5, scheduler: MainScheduler.instance).subscribe(onNext: { [unowned self] (_) in
+//            self.step.accept(DemoStep.settings)
+//        }).disposed(by: self.disposeBag)
     }
 
     @objc func settings () {


### PR DESCRIPTION
This commit:
- flattens the subscription chains in the FlowCoordinator because
nested subscriptions are not a good practice
- regenerates the documentation
- adds an example of a "periodic step trigerring" in the Wishlist Stepper