### PR TITLE
swap root flow + demo hierarchy edit

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.1.0"
+github "ReactiveX/RxSwift" "4.1.1"

--- a/RxFlow.xcodeproj/project.pbxproj
+++ b/RxFlow.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1A8FBE781FF9783100389464 /* RxFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE771FF9783100389464 /* RxFlowTests.swift */; };
 		1A8FBE7A1FF9783100389464 /* RxFlow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AF8548C1FF8328D00271B52 /* RxFlow.framework */; };
 		1AF8549D1FF8328D00271B52 /* RxFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF8548F1FF8328D00271B52 /* RxFlow.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		287F848220234A1D0058503B /* ContainerVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F848120234A1D0058503B /* ContainerVC.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		1AF8548C1FF8328D00271B52 /* RxFlow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxFlow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AF8548F1FF8328D00271B52 /* RxFlow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxFlow.h; sourceTree = "<group>"; };
 		1AF854901FF8328D00271B52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		287F848120234A1D0058503B /* ContainerVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerVC.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +151,7 @@
 				1A8FBDF01FF8337800389464 /* Step.swift */,
 				1A8FBDEE1FF8337700389464 /* Presentable.swift */,
 				1A8FBDE71FF8337700389464 /* Stepper.swift */,
+				287F848120234A1D0058503B /* ContainerVC.swift */,
 			);
 			path = RxFlow;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				1A8FBDF21FF8337800389464 /* UIViewController+Presentable.swift in Sources */,
 				1A8FBDF71FF8337800389464 /* UIWindow+Rx.swift in Sources */,
 				1A8FBDF81FF8337800389464 /* Coordinator.swift in Sources */,
+				287F848220234A1D0058503B /* ContainerVC.swift in Sources */,
 				1A8FBDF51FF8337800389464 /* UIWindow+Presentable.swift in Sources */,
 				1A8FBDF91FF8337800389464 /* Rx+Pausable.swift in Sources */,
 				1A8FBDFE1FF8337800389464 /* Flow.swift in Sources */,

--- a/RxFlow/ContainerVC.swift
+++ b/RxFlow/ContainerVC.swift
@@ -1,0 +1,30 @@
+//
+//  ContainerVC.swift
+//  RxFlow
+//
+//  Created by Jozef Matus on 01/02/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import UIKit
+/// Simple custom container which will hold root views
+public class ContainerVC: UIViewController {
+
+	var rootFlow: Flow?
+
+	func set(RootFlow flow: Flow) {
+		self.rootFlow = flow
+		self.addChildViewController(rootFlow!.root)
+		rootFlow!.root.view.frame = self.view.frame
+		self.view.addSubview(rootFlow!.root.view)
+		rootFlow!.root.didMove(toParentViewController: self)
+	}
+
+	func removeContent() {
+		self.rootFlow?.root.willMove(toParentViewController: nil)
+		self.rootFlow?.root.view.removeFromSuperview()
+		self.rootFlow?.root.removeFromParentViewController()
+		self.rootFlow = nil
+	}
+}
+

--- a/RxFlow/NextFlowItem.swift
+++ b/RxFlow/NextFlowItem.swift
@@ -22,14 +22,20 @@ public struct NextFlowItem {
     /// Presentable is displayed
     let nextStepper: Stepper
 
+	/// Flag to determin if this flow is suppose to be root in UIWindow, this mechanism
+	/// proved support to swap flows. In future it would be good to have mechanism to
+	/// swap flows event in spacific place in hierarchy.
+	var isRootFlowItem: Bool
+
     /// Initialize a new NextFlowItem
     ///
     /// - Parameters:
     ///   - nextPresentable: the next presentable to be handled by the Coordinator
     ///   - nextStepper: the next Steper to be handled by the Coordinator
-    public init(nextPresentable presentable: Presentable, nextStepper stepper: Stepper) {
+    public init(nextPresentable presentable: Presentable, nextStepper stepper: Stepper, isRootFlowable isRoot: Bool = false) {
         self.nextPresentable = presentable
         self.nextStepper = stepper
+		self.isRootFlowItem = isRoot
     }
 }
 

--- a/RxFlowDemo/Cartfile.resolved
+++ b/RxFlowDemo/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/Reusable" "4.0.1"
-github "ReactiveX/RxSwift" "4.1.0"
+github "ReactiveX/RxSwift" "4.1.1"

--- a/RxFlowDemo/RxFlowDemo.xcodeproj/project.pbxproj
+++ b/RxFlowDemo/RxFlowDemo.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		1A8FBE261FF8480C00389464 /* WishlistFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE211FF8480B00389464 /* WishlistFlow.swift */; };
 		1A8FBE271FF8480C00389464 /* DemoStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE221FF8480C00389464 /* DemoStep.swift */; };
 		1A8FBE281FF8480C00389464 /* SettingsFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE231FF8480C00389464 /* SettingsFlow.swift */; };
-		1A8FBE291FF8480C00389464 /* MainFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE241FF8480C00389464 /* MainFlow.swift */; };
 		1A8FBE2A1FF8480C00389464 /* WatchedFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE251FF8480C00389464 /* WatchedFlow.swift */; };
 		1A8FBE2D1FF84B2500389464 /* ViewModelBased.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE2C1FF84B2500389464 /* ViewModelBased.swift */; };
 		1A8FBE341FF84B5300389464 /* CastsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE2F1FF84B5300389464 /* CastsHelper.swift */; };
@@ -50,6 +49,8 @@
 		1AF854B31FF832AE00271B52 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF854B21FF832AE00271B52 /* AppDelegate.swift */; };
 		1AF854BA1FF832AE00271B52 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1AF854B91FF832AE00271B52 /* Assets.xcassets */; };
 		1AF854BD1FF832AE00271B52 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1AF854BB1FF832AE00271B52 /* LaunchScreen.storyboard */; };
+		287F8484202353A10058503B /* ApiFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F8483202353A10058503B /* ApiFlow.swift */; };
+		287FDBC0202358900024C70E /* TabFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287FDBBF202358900024C70E /* TabFlow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -73,7 +74,6 @@
 		1A8FBE211FF8480B00389464 /* WishlistFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WishlistFlow.swift; sourceTree = "<group>"; };
 		1A8FBE221FF8480C00389464 /* DemoStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoStep.swift; sourceTree = "<group>"; };
 		1A8FBE231FF8480C00389464 /* SettingsFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsFlow.swift; sourceTree = "<group>"; };
-		1A8FBE241FF8480C00389464 /* MainFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainFlow.swift; sourceTree = "<group>"; };
 		1A8FBE251FF8480C00389464 /* WatchedFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchedFlow.swift; sourceTree = "<group>"; };
 		1A8FBE2C1FF84B2500389464 /* ViewModelBased.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelBased.swift; sourceTree = "<group>"; };
 		1A8FBE2F1FF84B5300389464 /* CastsHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CastsHelper.swift; sourceTree = "<group>"; };
@@ -111,6 +111,8 @@
 		1AF854B91FF832AE00271B52 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1AF854BC1FF832AE00271B52 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1AF854BE1FF832AE00271B52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		287F8483202353A10058503B /* ApiFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiFlow.swift; sourceTree = "<group>"; };
+		287FDBBF202358900024C70E /* TabFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabFlow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,11 +143,12 @@
 		1A8FBE1F1FF847EB00389464 /* Flows */ = {
 			isa = PBXGroup;
 			children = (
+				287FDBBF202358900024C70E /* TabFlow.swift */,
 				1A8FBE221FF8480C00389464 /* DemoStep.swift */,
-				1A8FBE241FF8480C00389464 /* MainFlow.swift */,
 				1A8FBE231FF8480C00389464 /* SettingsFlow.swift */,
 				1A8FBE251FF8480C00389464 /* WatchedFlow.swift */,
 				1A8FBE211FF8480B00389464 /* WishlistFlow.swift */,
+				287F8483202353A10058503B /* ApiFlow.swift */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -409,11 +412,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A8FBE2A1FF8480C00389464 /* WatchedFlow.swift in Sources */,
+				287FDBC0202358900024C70E /* TabFlow.swift in Sources */,
 				1A8FBE6F1FF84C2C00389464 /* WatchedViewController.swift in Sources */,
 				1A8FBE481FF84BB200389464 /* SettingsListViewController.swift in Sources */,
 				1A8FBE5E1FF84BFE00389464 /* WishlistViewModel.swift in Sources */,
 				1A8FBE631FF84BFE00389464 /* CastDetailViewModel.swift in Sources */,
-				1A8FBE291FF8480C00389464 /* MainFlow.swift in Sources */,
 				1A8FBE611FF84BFE00389464 /* MovieDetailViewController.swift in Sources */,
 				1A8FBE3D1FF84B7E00389464 /* Cast.swift in Sources */,
 				1A8FBE621FF84BFE00389464 /* MovieDetailViewModel.swift in Sources */,
@@ -432,6 +435,7 @@
 				1A8FBE4C1FF84BB200389464 /* SettingsViewController.swift in Sources */,
 				1A8FBE371FF84B5300389464 /* CastsRepository.swift in Sources */,
 				1A8FBE261FF8480C00389464 /* WishlistFlow.swift in Sources */,
+				287F8484202353A10058503B /* ApiFlow.swift in Sources */,
 				1A8FBE2D1FF84B2500389464 /* ViewModelBased.swift in Sources */,
 				1A8FBE671FF84BFE00389464 /* CastDetailViewController.swift in Sources */,
 				1A8FBE6A1FF84C2400389464 /* MovieCollectionViewCell.swift in Sources */,

--- a/RxFlowDemo/RxFlowDemo/AppDelegate.swift
+++ b/RxFlowDemo/RxFlowDemo/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var coordinator = Coordinator()
     let movieService = MoviesService()
     lazy var mainFlow = {
-        return MainFlow(with: self.movieService)
+        return ApiFlow(with: self.movieService)
     }()
 
     func application(_ application: UIApplication,
@@ -31,12 +31,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print ("did navigate to flow=\(flow) and step=\(step)")
         }).disposed(by: self.disposeBag)
 
-        Flows.whenReady(flow1: mainFlow, block: { [unowned window] (root) in
-            window.rootViewController = root
-        })
-
         coordinator.coordinate(flow: mainFlow, withStepper: OneStepper(withSingleStep: DemoStep.apiKey))
-
+		window.rootViewController = coordinator.container
         return true
     }
 

--- a/RxFlowDemo/RxFlowDemo/Flows/ApiFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/ApiFlow.swift
@@ -1,0 +1,50 @@
+//
+//  ApiFlow.swift
+//  RxFlowDemo
+//
+//  Created by Jozef Matus on 01/02/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import RxFlow
+import RxSwift
+
+class ApiFlow: Flow {
+
+	var root: UIViewController {
+		return self.rootViewController
+	}
+
+	private let rootViewController: UINavigationController
+	private let service: MoviesService
+
+	init(with service: MoviesService) {
+		self.rootViewController = UINavigationController()
+		self.service = service
+	}
+
+	func navigate(to step: Step) -> NextFlowItems {
+		guard let step = step as? DemoStep else { return NextFlowItems.stepNotHandled }
+
+		switch step {
+		case .apiKey:
+			return navigationToApiScreen()
+		case .apiKeyIsComplete:
+			return navigationToTabFlow()
+		default:
+			return NextFlowItems.stepNotHandled
+		}
+	}
+
+	private func navigationToApiScreen () -> NextFlowItems {
+		let settingsViewController = SettingsViewController.instantiate()
+		rootViewController.pushViewController(settingsViewController, animated: false)
+		return NextFlowItems.one(flowItem: NextFlowItem(nextPresentable: settingsViewController, nextStepper: settingsViewController))
+	}
+
+	private func navigationToTabFlow() -> NextFlowItems {
+		let tabFlow = TabFlow(with: self.service)
+		return NextFlowItems.one(flowItem: NextFlowItem(nextPresentable: tabFlow, nextStepper: OneStepper(withSingleStep: DemoStep.apiKeyIsComplete), isRootFlowable: true))
+	}
+
+}

--- a/RxFlowDemo/RxFlowDemo/Flows/TabFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/TabFlow.swift
@@ -9,18 +9,17 @@
 import RxFlow
 import RxSwift
 
-class MainFlow: Flow {
+class TabFlow: Flow {
 
     var root: UIViewController {
         return self.rootViewController
     }
 
-    private let rootViewController: UINavigationController
+    private let rootViewController: UITabBarController
     private let service: MoviesService
 
     init(with service: MoviesService) {
-        self.rootViewController = UINavigationController()
-        self.rootViewController.setNavigationBarHidden(true, animated: false)
+        self.rootViewController = UITabBarController()
         self.service = service
     }
 
@@ -28,23 +27,22 @@ class MainFlow: Flow {
         guard let step = step as? DemoStep else { return NextFlowItems.stepNotHandled }
 
         switch step {
-        case .apiKey:
-            return navigationToApiScreen()
         case .apiKeyIsComplete:
             return navigationToDashboardScreen()
         default:
             return NextFlowItems.stepNotHandled
         }
     }
-
-    private func navigationToApiScreen () -> NextFlowItems {
-        let settingsViewController = SettingsViewController.instantiate()
-        rootViewController.pushViewController(settingsViewController, animated: false)
-        return NextFlowItems.one(flowItem: NextFlowItem(nextPresentable: settingsViewController, nextStepper: settingsViewController))
-    }
+//	        case .apiKey:
+//	            return navigationToApiScreen()
+//    private func navigationToApiScreen () -> NextFlowItems {
+//        let settingsViewController = SettingsViewController.instantiate()
+//        rootViewController.pushViewController(settingsViewController, animated: false)
+//        return NextFlowItems.one(flowItem: NextFlowItem(nextPresentable: settingsViewController, nextStepper: settingsViewController))
+//    }
+//	NextFlowItem(nextPresentable: wishListFlow, nextStepper: wishlistStepper),
 
     private func navigationToDashboardScreen () -> NextFlowItems {
-        let tabbarController = UITabBarController()
         let wishlistStepper = WishlistStepper()
         let wishListFlow = WishlistFlow(withService: self.service, andStepper: wishlistStepper)
         let watchedFlow = WatchedFlow(withService: self.service)
@@ -57,11 +55,10 @@ class MainFlow: Flow {
             root2.tabBarItem = tabBarItem2
             root2.title = "Watched"
 
-            tabbarController.setViewControllers([root1, root2], animated: false)
-            self.rootViewController.pushViewController(tabbarController, animated: true)
+            self.rootViewController.setViewControllers([root1, root2], animated: false)
         })
 
-        return NextFlowItems.multiple(flowItems: [NextFlowItem(nextPresentable: wishListFlow, nextStepper: wishlistStepper),
-                                                  NextFlowItem(nextPresentable: watchedFlow, nextStepper: OneStepper(withSingleStep: DemoStep.movieList))])
+		return NextFlowItems.multiple(flowItems: [NextFlowItem(nextPresentable: wishListFlow, nextStepper: wishlistStepper),
+												  NextFlowItem(nextPresentable: watchedFlow, nextStepper: OneStepper(withSingleStep: DemoStep.movieList))])
     }
 }


### PR DESCRIPTION
## Description
I've created flag in NextFlowItem (isRootFlowItem) which indicates whether that item should be on top of hierarchy. Then there is new class called ContainerVC which is simple container view controller which is inside Coordinator class, you then swap the root flows there.

Then Coordinator's `navigateToAnotherFlow:` has been changed to support swap root flow. 
Coordinator's `flowCoordinators` now has didSet to automatically anchor root view for first flow.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
