### PR TITLE
rewrite dismissed observable to make sure it's called on the right vi…

### DIFF
--- a/RxFlow/Extensions/UIViewController+Rx.swift
+++ b/RxFlow/Extensions/UIViewController+Rx.swift
@@ -22,7 +22,10 @@ extension Reactive where Base: UIViewController {
 
     /// Rx observable, triggered when the view is being dismissed
     public var dismissed: ControlEvent<Bool> {
-        let source = self.sentMessage(#selector(Base.dismiss)).map { $0.first as? Bool ?? false }
+        let source = self.sentMessage(#selector(Base.viewWillDisappear))
+            .filter { _ in self.base.isBeingDismissed }
+            .map { _ in false }
+
         return ControlEvent(events: source)
     }
 


### PR DESCRIPTION
…ew controller

## Description
This pull request replaces the old `dismissed`observable extension for UIViewControllers with a better one that catches all cases.

## Checklist
- [X] this PR is based on develop or a 'develop related' branch
- [X] the commits inside this PR have explicit commit messages
- [X] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
