### PR TITLE
Avoid flow deallocation when return .end on navigate(to:)

### DIFF
--- a/RxFlow.xcodeproj/project.pbxproj
+++ b/RxFlow.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		1A8FBE781FF9783100389464 /* RxFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8FBE771FF9783100389464 /* RxFlowTests.swift */; };
 		1A8FBE7A1FF9783100389464 /* RxFlow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AF8548C1FF8328D00271B52 /* RxFlow.framework */; };
 		1AF8549D1FF8328D00271B52 /* RxFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF8548F1FF8328D00271B52 /* RxFlow.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4810327E205FB0E000E4582A /* TabWithStepperFlowContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4810327D205FB0E000E4582A /* TabWithStepperFlowContainer.swift */; };
+		48103296205FF69A00E4582A /* Flow+Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48103295205FF69A00E4582A /* Flow+Tabs.swift */; };
+		4883FBD42059929200C9D5B6 /* TabFlowContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4883FBD32059929200C9D5B6 /* TabFlowContainer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +64,9 @@
 		1AF8548C1FF8328D00271B52 /* RxFlow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxFlow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AF8548F1FF8328D00271B52 /* RxFlow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxFlow.h; sourceTree = "<group>"; };
 		1AF854901FF8328D00271B52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4810327D205FB0E000E4582A /* TabWithStepperFlowContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWithStepperFlowContainer.swift; sourceTree = "<group>"; };
+		48103295205FF69A00E4582A /* Flow+Tabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Flow+Tabs.swift"; sourceTree = "<group>"; };
+		4883FBD32059929200C9D5B6 /* TabFlowContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabFlowContainer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,10 +151,13 @@
 				1A8FBDEF1FF8337700389464 /* HasDisposeBag.swift */,
 				1A8FBDEB1FF8337700389464 /* Coordinator.swift */,
 				1A8FBDF11FF8337800389464 /* Flow.swift */,
+				48103295205FF69A00E4582A /* Flow+Tabs.swift */,
 				1A8FBDE91FF8337700389464 /* NextFlowItem.swift */,
 				1A8FBDF01FF8337800389464 /* Step.swift */,
 				1A8FBDEE1FF8337700389464 /* Presentable.swift */,
 				1A8FBDE71FF8337700389464 /* Stepper.swift */,
+				4883FBD32059929200C9D5B6 /* TabFlowContainer.swift */,
+				4810327D205FB0E000E4582A /* TabWithStepperFlowContainer.swift */,
 			);
 			path = RxFlow;
 			sourceTree = "<group>";
@@ -297,12 +306,15 @@
 				1A8FBDFB1FF8337800389464 /* Presentable.swift in Sources */,
 				1A8FBDF21FF8337800389464 /* UIViewController+Presentable.swift in Sources */,
 				1A8FBDF71FF8337800389464 /* UIWindow+Rx.swift in Sources */,
+				48103296205FF69A00E4582A /* Flow+Tabs.swift in Sources */,
 				1A8FBDF81FF8337800389464 /* Coordinator.swift in Sources */,
+				4810327E205FB0E000E4582A /* TabWithStepperFlowContainer.swift in Sources */,
 				1A8FBDF51FF8337800389464 /* UIWindow+Presentable.swift in Sources */,
 				1A8FBDF91FF8337800389464 /* Rx+Pausable.swift in Sources */,
 				1A8FBDFE1FF8337800389464 /* Flow.swift in Sources */,
 				1A8FBDF61FF8337800389464 /* NextFlowItem.swift in Sources */,
 				1A8FBDFD1FF8337800389464 /* Step.swift in Sources */,
+				4883FBD42059929200C9D5B6 /* TabFlowContainer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxFlow/Coordinator.swift
+++ b/RxFlow/Coordinator.swift
@@ -119,7 +119,7 @@ class FlowCoordinator: HasDisposeBag {
                     // to dismiss the child Flow Root for instance (because this is the parent who had the responsability
                     // to present the child Flow Root as well)
                     self.dismissFlow.onNext(Void())
-                    self.delegate.endFlowCoordinator(withIdentifier: self.identifier)
+                    //self.delegate.endFlowCoordinator(withIdentifier: self.identifier)
                     if  let parentFlowCoordinator = self.parentFlowCoordinator {
                         let stepContextForParentFlow = StepContext(with: stepToSendToParentFlow)
                         stepContextForParentFlow.fromChildFlow = self.flow

--- a/RxFlow/Extensions/UIWindow+Rx.swift
+++ b/RxFlow/Extensions/UIWindow+Rx.swift
@@ -12,8 +12,8 @@ import RxSwift
 extension Reactive where Base: UIWindow {
 
     /// Rx Single that is triggered once the UIWindow is displayed
-    public var windowDidAppear: Single<Void> {
-        return self.sentMessage(#selector(Base.makeKeyAndVisible)).map {_ in return Void()}.take(1).asSingle()
+    public var windowDidAppear: Observable<Void> {
+        return self.sentMessage(#selector(Base.makeKeyAndVisible)).map {_ in return Void()}
     }
 
 }

--- a/RxFlow/Flow+Tabs.swift
+++ b/RxFlow/Flow+Tabs.swift
@@ -1,0 +1,160 @@
+//
+//  Flow+Tabs.swift
+//  RxFlow
+//
+//  Created by Alexander Cyon on 2018-03-19.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+import UIKit
+
+public typealias TabsReady<RootViewController: UIViewController> = ([(RootViewController, UITabBarItem)]) -> Void
+
+public extension Flows {
+    
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the block is executed
+    ///
+    /// - Parameters:
+    ///   - tabs: List of Tab containing flows which should be observed
+    ///   - block: block to execute whenever the Flows are ready to use
+    public static func whenReady<RootType: UIViewController>(
+        tabs: [TabFlowContainer],
+        block: @escaping TabsReady<RootType>) {
+        let flows = tabs.map { $0.flow }
+        guard case let roots = flows.flatMap({ $0.root as? RootType }), roots.count == tabs.count else {
+            fatalError ("Type mismatch, Flows roots types do not match the types awaited in the block")
+        }
+        
+        let tabbedRoots = zip(roots, tabs.map { $0.tab }).map { ($0.0, $0.1) }
+        
+        _ = Observable<Void>.zip(flows.map { $0.rxFlowReady.asObservable() }) { _ in return Void() }
+            .take(1)
+            .subscribe(onNext: { _ in
+                block(tabbedRoots)
+            })
+    }
+}
+
+//MARK: - Returning [NextFlowItem]
+public extension Flows {
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the block is executed
+    ///
+    /// - Parameters:
+    ///   - tabsWithSteppers: List of Tab and stepper contains flows which should be observed
+    ///   - weak: Target to weakify being used in the `block` parameter
+    ///   - block: block executed when the Flow in each tab is ready, exposing the rootViewController having the tabItem set
+    /// - Returns: the NextFlowItems created from the tabs
+    public static func whenReady<Target: AnyObject, RootType: UIViewController>(
+        tabsWithSteppers tabs: [TabWithStepperFlowContainer],
+        weak target: Target,
+        block: @escaping (Target, [RootType]) -> Void) -> [NextFlowItem] {
+        
+        Flows.whenReady(tabs: tabs) { [weak target] (tabbedRoots: [(RootType, UITabBarItem)]) -> Void in
+            guard let target = target else { print("⚠️ WARNING Target was nil, this is probably unwanted."); return }
+            tabbedRoots.forEach { $0.0.tabBarItem = $0.1 }
+            block(target, tabbedRoots.map { $0.0 })
+        }
+        
+        // We can safely return the array of NextFlowItems since it is not dependent on the async call above
+        return tabs.map { NextFlowItem(nextPresentable: $0.flow, nextStepper: $0.stepper) }
+    }
+    
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the block is executed
+    ///
+    /// - Parameters:
+    ///   - tabsWithSteppers: List of Tab and stepper contains flows which should be observed
+    ///   - weak: Target to weakify being used in the `block` parameter
+    ///   - block: block executed when the Flow in each tab is ready, exposing the rootViewController having the tabItem set
+    /// - Returns: the NextFlowItems created from the tabs
+    public static func whenReady<Target: AnyObject>(
+        createTabBarWith tabs: [TabWithStepperFlowContainer],
+        weak target: Target,
+        block: @escaping (Target, UITabBarController) -> Void) -> [NextFlowItem] {
+
+        Flows.whenReady(tabs: tabs){ [weak target] (tabbedRoots: [(UIViewController, UITabBarItem)]) -> Void in
+            guard let target = target else { print("⚠️ WARNING Target was nil, this is probably unwanted."); return }
+            tabbedRoots.forEach { $0.0.tabBarItem = $0.1 }
+            let tabBarController = UITabBarController()
+            tabBarController.setViewControllers(tabbedRoots.map { $0.0 }, animated: false)
+            block(target, tabBarController)
+        }
+        
+        // We can safely return the array of NextFlowItems since it is not dependent on the async call above
+        return tabs.map { NextFlowItem(nextPresentable: $0.flow, nextStepper: $0.stepper) }
+    }
+    
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the rootViewControllers are set on the tabBarController.
+    ///
+    /// - Parameters:
+    ///   - tabsWithSteppers: List of Tab that contains flows that should be observed
+    ///   - tabBarController: UITabBarController that will get `rootViewControllers` property set using the rootViewController of each tab.
+    ///   - animated: Bool that controls whether or not setting the `rootViewControllers` property should be animated.
+    /// - Returns: the NextFlowItems created from the tabs
+    public static func whenReady(
+        setupTabBarController tabBarController: UITabBarController,
+        with tabs: [TabWithStepperFlowContainer],
+        animated: Bool = false) -> [NextFlowItem] {
+        
+        Flows.whenReady(tabs: tabs) { (tabbedRoots: [(UIViewController, UITabBarItem)]) -> Void in
+            tabbedRoots.forEach { $0.0.tabBarItem = $0.1 }
+            tabBarController.setViewControllers(tabbedRoots.map { $0.0 }, animated: animated)
+        }
+        
+        // We can safely return the array of NextFlowItems since it is not dependent on the async call above
+        return tabs.map { NextFlowItem(nextPresentable: $0.flow, nextStepper: $0.stepper) }
+    }
+}
+
+//MARK: - NextFlowItems.multiple Convenience
+public extension Flows {
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the block is executed
+    ///
+    /// - Parameters:
+    ///   - tabsWithSteppers: List of OneStepperTab that contains flows that should be observed
+    ///   - weak: Target to weakify being used in the `block` parameter
+    ///   - block: block to execute whenever the Flows are ready to use, having set the tabItems on each viewController
+    /// - Returns: the NextFlowItems created from the tabs, as a "multiple" type
+    public static func whenReady<Target: AnyObject, RootType: UIViewController>(
+        tabsWithSteppers tabs: [TabWithStepperFlowContainer],
+        weak target: Target,
+        block: @escaping (Target, [RootType]) -> Void) -> NextFlowItems {
+        return .multiple(flowItems: Flows.whenReady(tabsWithSteppers: tabs, weak: target, block: block))
+    }
+    
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the block is executed
+    ///
+    /// - Parameters:
+    ///   - tabsWithSteppers: List of OneStepperTab that contains flows that should be observed
+    ///   - weak: Target to weakify being used in the `block` parameter
+    ///   - block: block to execute whenever the Flows are ready to use, having set the tabItems on each viewController
+    /// - Returns: the NextFlowItems created from the tabs, as a "multiple" type
+    public static func whenReady(
+        setupTabBarController tabBarController: UITabBarController,
+        with tabs: [TabWithStepperFlowContainer],
+        animated: Bool = false) -> NextFlowItems {
+        return .multiple(flowItems: Flows.whenReady(setupTabBarController: tabBarController, with: tabs, animated: animated))
+    }
+    
+    /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
+    /// Once it is the case, the block is executed
+    ///
+    /// - Parameters:
+    ///   - tabsWithSteppers: List of Tab and stepper contains flows which should be observed
+    ///   - weak: Target to weakify being used in the `block` parameter
+    ///   - block: block executed when the Flow in each tab is ready, exposing the rootViewController having the tabItem set
+    /// - Returns: the NextFlowItems created from the tabs
+    public static func whenReady<Target: AnyObject>(
+        createTabBarWith tabs: [TabWithStepperFlowContainer],
+        weak target: Target,
+        block: @escaping (Target, UITabBarController) -> Void) -> NextFlowItems {
+        return .multiple(flowItems: Flows.whenReady(createTabBarWith: tabs, weak: target, block: block))
+    }
+    
+}

--- a/RxFlow/Flow.swift
+++ b/RxFlow/Flow.swift
@@ -25,7 +25,7 @@ public protocol Flow: Presentable {
     var root: Presentable { get }
 }
 
-extension Flow {
+public extension Flow {
 
     /// Inner/hidden Rx Subject in which we push the "Ready" event
     var flowReadySubject: PublishSubject<Bool> {
@@ -49,7 +49,7 @@ extension Flow {
 
 /// Utility functions to synchronize Flows readyness
 public class Flows {
-
+    
     /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
     /// Once it is the case, the block is executed
     ///

--- a/RxFlow/Presentable.swift
+++ b/RxFlow/Presentable.swift
@@ -60,7 +60,7 @@ extension Presentable where Self: Flow {
 extension Presentable where Self: UIWindow {
     /// Rx Observable (Single trait) triggered when this UIWindow is displayed for the first time
     public var rxFirstTimeVisible: Single<Void> {
-        return self.rx.windowDidAppear
+        return self.rx.windowDidAppear.asSingle()
     }
 
     /// Rx Observable that triggers a bool indicating if the current UIWindow is being displayed

--- a/RxFlow/TabFlowContainer.swift
+++ b/RxFlow/TabFlowContainer.swift
@@ -1,0 +1,36 @@
+//
+//  TabFlowContainer.swift
+//  RxFlow
+//
+//  Created by Alexander Cyon on 2018-03-14.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import Foundation
+
+open class TabFlowContainer {
+    public let flow: Flow
+    public let tab: UITabBarItem
+    public init(flow: Flow, tab: UITabBarItem) {
+        self.flow = flow
+        self.tab = tab
+    }
+}
+
+public extension TabFlowContainer {
+
+    public convenience init(flow: Flow, title: String) {
+        self.init(flow: flow, title: title)
+    }
+    
+    public convenience init(flow: Flow, image: String, selectedImage: UIImage? = nil) {
+        self.init(flow: flow, image: image, selectedImage: selectedImage)
+    }
+    
+    public convenience init(flow: Flow,
+                            title: String?,
+                            image: UIImage? = nil,
+                            selectedImage: UIImage? = nil) {
+        self.init(flow: flow, tab: UITabBarItem(title: title, image: image, selectedImage: selectedImage))
+    }
+}

--- a/RxFlow/TabWithStepperFlowContainer.swift
+++ b/RxFlow/TabWithStepperFlowContainer.swift
@@ -1,0 +1,40 @@
+//
+//  TabWithStepperFlowContainer.swift
+//  RxFlow
+//
+//  Created by Alexander Cyon on 2018-03-19.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import Foundation
+
+open class TabWithStepperFlowContainer: TabFlowContainer {
+    public let stepper: Stepper
+    public init(flow: Flow, tab: UITabBarItem, stepper: Stepper) {
+        self.stepper = stepper
+        super.init(flow: flow, tab: tab)
+    }
+}
+
+public extension TabWithStepperFlowContainer {
+    
+    public convenience init(flow: Flow,
+                            title: String,
+                            image: UIImage? = nil,
+                            selectedImage: UIImage? = nil,
+                            stepper: Stepper) {
+        let tab = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
+        self.init(flow: flow, tab: tab, stepper: stepper)
+    }
+    
+    public convenience init(flow: Flow,
+                            title: String,
+                            image: UIImage? = nil,
+                            selectedImage: UIImage? = nil,
+                            withSingleStep step: Step,
+                            stepperFactory: ((Step) -> Stepper) = OneStepper.init(withSingleStep:)) {
+        let tab = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
+        self.init(flow: flow, tab: tab, stepper: stepperFactory(step))
+    }
+}
+

--- a/RxFlowDemo/RxFlowDemo/Flows/DashboardFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/DashboardFlow.swift
@@ -12,10 +12,10 @@ import RxFlow
 class DashboardFlow: Flow {
 
     var root: Presentable {
-        return self.rootViewController
+        return tabBarController
     }
 
-    let rootViewController = UITabBarController()
+    let tabBarController = UITabBarController()
     private let services: AppServices
 
     init(withServices services: AppServices) {
@@ -33,24 +33,13 @@ class DashboardFlow: Flow {
         }
 
     }
-
-    private func navigateToDashboard () -> NextFlowItems {
+    
+    func navigateToDashboard() -> NextFlowItems {
         let wishlistStepper = WishlistStepper()
         let wishListFlow = WishlistFlow(withServices: self.services, andStepper: wishlistStepper)
-        let watchedFlow = WatchedFlow(withServices: self.services)
-
-        Flows.whenReady(flow1: wishListFlow, flow2: watchedFlow, block: { [unowned self] (root1: UINavigationController, root2: UINavigationController) in
-            let tabBarItem1 = UITabBarItem(title: "Wishlist", image: UIImage(named: "wishlist"), selectedImage: nil)
-            let tabBarItem2 = UITabBarItem(title: "Watched", image: UIImage(named: "watched"), selectedImage: nil)
-            root1.tabBarItem = tabBarItem1
-            root1.title = "Wishlist"
-            root2.tabBarItem = tabBarItem2
-            root2.title = "Watched"
-
-            self.rootViewController.setViewControllers([root1, root2], animated: false)
-        })
-
-        return NextFlowItems.multiple(flowItems: [NextFlowItem(nextPresentable: wishListFlow, nextStepper: wishlistStepper),
-                                                  NextFlowItem(nextPresentable: watchedFlow, nextStepper: OneStepper(withSingleStep: DemoStep.movieList))])
+        return Flows.whenReady(setupTabBarController: tabBarController, with: [
+            TabWithStepperFlowContainer(flow: wishListFlow, title: "Wishlist", image: #imageLiteral(resourceName: "wishlist"), stepper: wishlistStepper),
+            TabWithStepperFlowContainer(flow: WatchedFlow(withServices: self.services), title: "Watched", image: #imageLiteral(resourceName: "watched"), withSingleStep: DemoStep.movieList)
+        ])
     }
 }


### PR DESCRIPTION
## Description
Attempt to solve the issue #48

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] this PR is based on develop or a 'develop related' branch
- [x ] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)