### PR TITLE
Use Date.timeIntervalSince1970 to create Coordinator identifier

### DIFF
--- a/RxFlow/Coordinator.swift
+++ b/RxFlow/Coordinator.swift
@@ -79,7 +79,7 @@ class FlowCoordinator: HasDisposeBag {
         self.stepper = stepper
         self.delegate = delegate
         self.parentFlowCoordinator = parentFlowCoordinator
-        self.identifier = "\(type(of: flow))-\(Date().timeIntervalSince1970)"
+        self.identifier = "\(type(of: flow))-\(UUID().uuidString)"
     }
 
     /// Launch the coordination process

--- a/RxFlow/Coordinator.swift
+++ b/RxFlow/Coordinator.swift
@@ -79,7 +79,7 @@ class FlowCoordinator: HasDisposeBag {
         self.stepper = stepper
         self.delegate = delegate
         self.parentFlowCoordinator = parentFlowCoordinator
-        self.identifier = "\(type(of: flow))-\(Date())"
+        self.identifier = "\(type(of: flow))-\(Date().timeIntervalSince1970)"
     }
 
     /// Launch the coordination process


### PR DESCRIPTION
## Description
I found this issue when creating a Flow for a UIPageViewController that dispatches many flows of the same type, at the same time.

Right now, to create a flow coordinator's identifier we use (FlowName)-(Date). Which prints something similar to "AppFlow-2018-08-19 19:49:40 +0000".
This only gives us granularity up to the second and does not create unique identifiers for multiple Flows of the same type being created within the same second.
Because the data structure that holds all the flowCoordinators' references is a Dictionary, when multiple flows of the same type are created at the same time, when we try to set them in the dictionary, only one flowCoordinator will be stored and the other references will be lost. This causes the Step events to be disposed.

This PR uses timeIntervalSince1970, which gives us sub-millisecond granularity.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] this PR is based on develop or a 'develop related' branch
- [x ] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
