### PR TITLE
Fixed small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ For instance, from the WishlistFlow, we launch the SettingsFlow in a popup.
 private func navigateToSettings () -> NextFlowItems {     
     let settingsStepper = SettingsStepper()
     let settingsFlow = SettingsFlow(withService: self.service, andStepper: settingsStepper)
-    Flows.whenReady(flow: settingsFlow, block: { [unowned self] (root: UISplitViewController) in
+    Flows.whenReady(flow1: settingsFlow, block: { [unowned self] (root: UISplitViewController) in
         self.rootViewController.present(root, animated: true)
     })
     return NextFlowItems.one(flowItem: NextFlowItem(nextPresentable: settingsFlow, nextStepper: settingsStepper))
@@ -254,7 +254,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }).disposed(by: self.disposeBag)
 
         // when the MainFlow is ready to be displayed, we assign its root the the Window
-        Flows.whenReady(flow: appFlow, block: { [unowned window] (flowRoot) in
+        Flows.whenReady(flow1: appFlow, block: { [unowned window] (flowRoot) in
             window.rootViewController = flowRoot
         })
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, link the related issues -->
`Flows.whenReady(flow:, block:)` was renamed to `Flows.whenReady(flow1:, block:)`.

Thus, using the code from the readme you will stumble upon the error "Argument labels '(flow:, block:)' do not match any available overloads".

This proposal fixes the typo.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] this PR is based on develop or a 'develop related' branch
- [X] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
