### PR TITLE
Add FlowContributors.multiple handling

### DIFF
--- a/RxFlowDemo/RxFlowDemo/Flows/DemoStep.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/DemoStep.swift
@@ -12,6 +12,7 @@ enum DemoStep: Step {
     // Global
     case logoutIsRequired
     case dashboardIsRequired
+    case alert(String)
 
     // Login
     case loginIsRequired

--- a/RxFlowDemo/RxFlowDemo/Flows/SettingsFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/SettingsFlow.swift
@@ -48,9 +48,18 @@ class SettingsFlow: Flow {
             return navigateToAboutScreen()
         case .settingsAreComplete:
             return .end(forwardToParentFlowWithStep: DemoStep.settingsAreComplete)
+        case let .alert(message):
+            return navigateToAlertScreen(message: message)
         default:
             return .none
         }
+    }
+
+    private func navigateToAlertScreen(message: String) -> FlowContributors {
+        let alert = UIAlertController(title: "Demo", message: message, preferredStyle: .alert)
+        alert.addAction(.init(title: "Cancel", style: .cancel))
+        rootViewController.present(alert, animated: true)
+        return .none
     }
 
     private func popToMasterViewController() -> FlowContributors {
@@ -78,8 +87,11 @@ class SettingsFlow: Flow {
             navigationBarItem.setRightBarButton(settingsButton, animated: false)
         }
 
-        return .multiple(flowContributors: [.contribute(withNextPresentable: settingsListViewController, withNextStepper: settingsListViewController),
-                                            .contribute(withNextPresentable: settingsLoginViewController, withNextStepper: settingsLoginViewController)])
+        return .multiple(flowContributors: [
+            .contribute(withNextPresentable: settingsListViewController, withNextStepper: settingsListViewController),
+            .contribute(withNextPresentable: settingsLoginViewController, withNextStepper: settingsLoginViewController),
+            .forwardToCurrentFlow(withStep: DemoStep.alert("Demo of multiple Flow Contributor"))
+        ])
     }
 
     private func navigateToLoginScreen() -> FlowContributors {


### PR DESCRIPTION
## Description
Add `FlowContributors.multiple` handling. Previously they were ignored.
These changes make possible sequentially dispatch few steps. For instance, navigate to a new flow and open alert.
Resolves - https://github.com/RxSwiftCommunity/RxFlow/issues/120

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
