### PR TITLE
Typo fixes in function argument description

### DIFF
--- a/RxFlow/FlowContributor.swift
+++ b/RxFlow/FlowContributor.swift
@@ -24,7 +24,7 @@ public enum FlowContributor {
 @available(*, deprecated, message: "You should use FlowContributors")
 public typealias NextFlowItems = FlowContributors
 
-/// FlowContributors reprent the next things that will trigger
+/// FlowContributors represent the next things that will trigger
 /// navigation actions inside a Flow
 ///
 /// - multiple: several FlowContributors will contribute to the Flow

--- a/RxFlow/FlowCoordinator.swift
+++ b/RxFlow/FlowCoordinator.swift
@@ -139,10 +139,10 @@ public final class FlowCoordinator: NSObject {
         }
     }
 
-    /// retrieve Steps from the combinaison presentable/stepper
+    /// retrieve Steps from the combination presentable/stepper
     ///
-    /// - Parameter nextPresentableAndStepper: the combinaison presentable/stepper that will generate new Steps
-    /// - Returns: the reactive sequence of Steps from the combinaison presentable/stepper
+    /// - Parameter nextPresentableAndStepper: the combination presentable/stepper that will generate new Steps
+    /// - Returns: the reactive sequence of Steps from the combination presentable/stepper
     private func steps (from nextPresentableAndStepper: PresentableAndStepper) -> Signal<Step> {
         return nextPresentableAndStepper
             .stepper


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, link the related issues -->
There were small typo(s) in the description of function arguments. This proposal fixes the typo.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
