### PR TITLE
Make framework use only extensions APIs for debug and archive

### DIFF
--- a/RxFlow.xcodeproj/project.pbxproj
+++ b/RxFlow.xcodeproj/project.pbxproj
@@ -550,6 +550,7 @@
 		1AF854A11FF8328D00271B52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -580,6 +581,7 @@
 		1AF854A21FF8328D00271B52 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
## Description
Removes warning generated when integrating the project via Carthage to a framework

<img width="591" alt="Screen Shot 2019-11-06 at 14 40 06" src="https://user-images.githubusercontent.com/508636/68344472-f21ede80-00a3-11ea-8b97-4e678702c58d.png">

## Checklist
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [x] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
