### PR TITLE
flow: leverage Single.zip(_:) operator

### DIFF
--- a/RxFlow/Flow.swift
+++ b/RxFlow/Flow.swift
@@ -68,20 +68,17 @@ public class Flows {
     ///   - block: block to execute whenever the Flows are ready to use
     public static func whenReady<RootType: UIViewController>(flows: [Flow],
                                                              block: @escaping ([RootType]) -> Void) {
-        let flowObservables = flows.map { $0.rxFlowReady.asObservable() }
+        let flowsReadinesses = flows.map { $0.rxFlowReady }
         let roots = flows.compactMap { $0.root as? RootType }
         guard roots.count == flows.count else {
             fatalError("Type mismatch, Flows roots types do not match the types awaited in the block")
         }
 
-        _ = Observable<Void>.zip(flowObservables) { _ in
-            return Void()
-        }
-        .take(1)
-        .asDriver(onErrorJustReturn: Void())
-        .drive(onNext: { _ in
-            block(roots)
-        })
+        _ = Single.zip(flowsReadinesses) { _ in Void() }
+            .asDriver(onErrorJustReturn: Void())
+            .drive(onNext: { _ in
+                block(roots)
+            })
     }
 
     // swiftlint:disable function_parameter_count
@@ -120,18 +117,15 @@ public class Flows {
                     fatalError("Type mismatch, Flows roots types do not match the types awaited in the block")
             }
 
-            _ = Observable<Void>.zip(flow1.rxFlowReady.asObservable(),
-                                     flow2.rxFlowReady.asObservable(),
-                                     flow3.rxFlowReady.asObservable(),
-                                     flow4.rxFlowReady.asObservable(),
-                                     flow5.rxFlowReady.asObservable()) { _, _, _, _, _ in
-                                        return Void()
-            }
-            .take(1)
-            .asDriver(onErrorJustReturn: Void())
-            .drive(onNext: { _ in
-                block(root1, root2, root3, root4, root5)
-            })
+            _ = Single.zip(flow1.rxFlowReady,
+                           flow2.rxFlowReady,
+                           flow3.rxFlowReady,
+                           flow4.rxFlowReady,
+                           flow5.rxFlowReady) { _, _, _, _, _ in Void() }
+                .asDriver(onErrorJustReturn: Void())
+                .drive(onNext: { _ in
+                    block(root1, root2, root3, root4, root5)
+                })
     }
     // swiftlint:enable function_parameter_count
 
@@ -165,13 +159,11 @@ public class Flows {
                     fatalError("Type mismatch, Flows roots types do not match the types awaited in the block")
             }
 
-            _ = Observable<Void>.zip(flow1.rxFlowReady.asObservable(),
-                                     flow2.rxFlowReady.asObservable(),
-                                     flow3.rxFlowReady.asObservable(),
-                                     flow4.rxFlowReady.asObservable()) { _, _, _, _ in
-                                        return Void()
+            _ = Single.zip(flow1.rxFlowReady,
+                           flow2.rxFlowReady,
+                           flow3.rxFlowReady,
+                           flow4.rxFlowReady) { _, _, _, _ in Void()
             }
-            .take(1)
             .asDriver(onErrorJustReturn: Void())
             .drive(onNext: { _ in
                 block(root1, root2, root3, root4)
@@ -203,16 +195,13 @@ public class Flows {
                     fatalError("Type mismatch, Flows roots types do not match the types awaited in the block")
             }
 
-            _ = Observable<Void>.zip(flow1.rxFlowReady.asObservable(),
-                                     flow2.rxFlowReady.asObservable(),
-                                     flow3.rxFlowReady.asObservable()) { _, _, _ in
-                                        return Void()
-            }
-            .take(1)
-            .asDriver(onErrorJustReturn: Void())
-            .drive(onNext: { _ in
-                block(root1, root2, root3)
-            })
+            _ = Single.zip(flow1.rxFlowReady,
+                           flow2.rxFlowReady,
+                           flow3.rxFlowReady) { _, _, _ in Void() }
+                .asDriver(onErrorJustReturn: Void())
+                .drive(onNext: { _ in
+                    block(root1, root2, root3)
+                })
     }
 
     /// Allow to be triggered only when Flows given as parameters are ready to be displayed.
@@ -231,15 +220,12 @@ public class Flows {
                 fatalError("Type mismatch, Flows root types do not match the types awaited in the block")
         }
 
-        _ = Observable<Void>.zip(flow1.rxFlowReady.asObservable(),
-                                 flow2.rxFlowReady.asObservable()) { _, _ in
-                                    return Void()
-        }
-        .take(1)
-        .asDriver(onErrorJustReturn: Void())
-        .drive(onNext: { _ in
-            block(root1, root2)
-        })
+        _ = Single.zip(flow1.rxFlowReady,
+                       flow2.rxFlowReady) { _, _ in Void() }
+            .asDriver(onErrorJustReturn: Void())
+            .drive(onNext: { _ in
+                block(root1, root2)
+            })
     }
 
     /// Allow to be triggered only when Flow given as parameters is ready to be displayed.


### PR DESCRIPTION
## Description
This commit removes unnecessary casts to Observable to perform zip
operations.
Single.zip(_:) is available since RxSwift 4.2.0.

## Checklist
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
