### PR TITLE
stepper: remove weftable mention in comment

### DIFF
--- a/RxFlow/Stepper.swift
+++ b/RxFlow/Stepper.swift
@@ -1,5 +1,5 @@
 //
-//  Weftable.swift
+//  Stepper.swift
 //  RxFlow
 //
 //  Created by Thibault Wittemberg on 17-07-25.


### PR DESCRIPTION
## Description
stepper: remove weftable mention in comment

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
