### PR TITLE
handle deep link

### DIFF
--- a/RxFlow/FlowCoordinator.swift
+++ b/RxFlow/FlowCoordinator.swift
@@ -112,6 +112,13 @@ public final class FlowCoordinator: NSObject {
             .disposed(by: self.disposeBag)
     }
 
+    /// allow to drive the navigation from the outside of a flow
+    /// - Parameter step: the step to navigate to. (it will be passed to all sub flows)
+    public func navigate(to step: Step) {
+        self.stepsRelay.accept(step)
+        self.childFlowCoordinators.values.forEach { $0.navigate(to: step) }
+    }
+
     private func performSideEffects(with flowContributor: FlowContributor) {
         switch flowContributor {
         case let .forwardToCurrentFlow(step):

--- a/RxFlowDemo/RxFlowDemo.xcodeproj/project.pbxproj
+++ b/RxFlowDemo/RxFlowDemo.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = RxFlowDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.warpfactor.RxFlowDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -634,7 +634,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = RxFlowDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.warpfactor.RxFlowDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/RxFlowDemo/RxFlowDemo/AppDelegate.swift
+++ b/RxFlowDemo/RxFlowDemo/AppDelegate.swift
@@ -48,6 +48,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    func application(_ application: UIApplication, didReceive notification: UILocalNotification) {
+        // example of deep link
+        // self.coordinator.navigate(to: DemoStep.aboutIsRequired)
+    }
+
 }
 
 struct AppServices: HasMoviesService, HasPreferencesService {

--- a/RxFlowDemo/RxFlowDemo/AppDelegate.swift
+++ b/RxFlowDemo/RxFlowDemo/AppDelegate.swift
@@ -12,7 +12,7 @@ import RxSwift
 import RxCocoa
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     let disposeBag = DisposeBag()
     var window: UIWindow?
@@ -45,14 +45,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             window.makeKeyAndVisible()
         }
 
+        UNUserNotificationCenter.current().delegate = self
+
         return true
     }
 
-    func application(_ application: UIApplication, didReceive notification: UILocalNotification) {
-        // example of deep link
-        // self.coordinator.navigate(to: DemoStep.aboutIsRequired)
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler(UNNotificationPresentationOptions.init(arrayLiteral: [.alert, .badge]))
     }
 
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        // example of how DeepLink can be handled
+        self.coordinator.navigate(to: DemoStep.movieIsPicked(withId: 23452))
+    }
 }
 
 struct AppServices: HasMoviesService, HasPreferencesService {

--- a/RxFlowDemo/RxFlowDemo/Features/Dashboard/Wishlist/WishlistViewController.storyboard
+++ b/RxFlowDemo/RxFlowDemo/Features/Dashboard/Wishlist/WishlistViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vFf-Cc-3q4">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vFf-Cc-3q4">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,11 +20,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="Rat-2D-82B">
-                                <rect key="frame" x="0.0" y="20" width="337" height="56"/>
+                                <rect key="frame" x="0.0" y="0.0" width="334" height="56"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="120" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="iEi-EE-aIH">
-                                <rect key="frame" x="0.0" y="76" width="375" height="591"/>
+                                <rect key="frame" x="0.0" y="56" width="375" height="561"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="gray" indentationWidth="10" reuseIdentifier="movieViewCell" rowHeight="117" id="bEP-Nr-J9n" customClass="MovieViewCell" customModule="RxFlowDemo" customModuleProvider="target">
@@ -81,21 +79,31 @@
                                 <sections/>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoDark" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a2y-tD-GeF">
-                                <rect key="frame" x="337" y="37" width="22" height="22"/>
+                                <rect key="frame" x="334" y="16" width="25" height="24"/>
                                 <connections>
                                     <action selector="about:" destination="vFf-Cc-3q4" eventType="touchUpInside" id="8QH-xj-KNY"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mVp-C9-yH3">
+                                <rect key="frame" x="105" y="629" width="165" height="30"/>
+                                <state key="normal" title="Send a notification in 5s"/>
+                                <connections>
+                                    <action selector="sendNotification:" destination="vFf-Cc-3q4" eventType="touchUpInside" id="cjm-An-LDg"/>
                                 </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="Rat-2D-82B" firstAttribute="leading" secondItem="TRD-V9-6JA" secondAttribute="leading" id="0bF-GV-Gz4"/>
+                            <constraint firstItem="mVp-C9-yH3" firstAttribute="top" secondItem="iEi-EE-aIH" secondAttribute="bottom" constant="12" id="0bZ-KH-2Jr"/>
                             <constraint firstAttribute="trailing" secondItem="a2y-tD-GeF" secondAttribute="trailing" constant="16" id="6Gc-EZ-cnF"/>
                             <constraint firstItem="Rat-2D-82B" firstAttribute="top" secondItem="J3f-A1-1Yj" secondAttribute="bottom" id="Lqf-Fk-X8N"/>
                             <constraint firstItem="a2y-tD-GeF" firstAttribute="leading" secondItem="Rat-2D-82B" secondAttribute="trailing" symbolic="YES" id="PeL-uA-T3F"/>
                             <constraint firstAttribute="trailing" secondItem="iEi-EE-aIH" secondAttribute="trailing" id="UDX-Fn-due"/>
+                            <constraint firstItem="REd-hg-ejW" firstAttribute="top" secondItem="mVp-C9-yH3" secondAttribute="bottom" constant="8" symbolic="YES" id="UNh-sI-wSr"/>
                             <constraint firstItem="iEi-EE-aIH" firstAttribute="top" secondItem="Rat-2D-82B" secondAttribute="bottom" id="X4D-oY-QCj"/>
-                            <constraint firstItem="REd-hg-ejW" firstAttribute="top" secondItem="iEi-EE-aIH" secondAttribute="bottom" id="hLg-9o-hRO"/>
+                            <constraint firstItem="mVp-C9-yH3" firstAttribute="centerX" secondItem="TRD-V9-6JA" secondAttribute="centerX" id="g3u-0q-mTC"/>
+                            <constraint firstItem="REd-hg-ejW" firstAttribute="top" secondItem="iEi-EE-aIH" secondAttribute="bottom" constant="50" id="hLg-9o-hRO"/>
                             <constraint firstItem="iEi-EE-aIH" firstAttribute="leading" secondItem="TRD-V9-6JA" secondAttribute="leading" id="hRN-Fb-fXj"/>
                             <constraint firstItem="a2y-tD-GeF" firstAttribute="centerY" secondItem="Rat-2D-82B" secondAttribute="centerY" id="tgL-o0-HcB"/>
                         </constraints>

--- a/RxFlowDemo/RxFlowDemo/Features/Dashboard/Wishlist/WishlistViewController.swift
+++ b/RxFlowDemo/RxFlowDemo/Features/Dashboard/Wishlist/WishlistViewController.swift
@@ -32,6 +32,23 @@ class WishlistViewController: UIViewController, StoryboardBased, ViewModelBased 
             .bind(to: self.steps)
     }
 
+    @IBAction func sendNotification(_ sender: UIButton) {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { (granted, _) in
+
+            guard granted else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = "Notification from RxFlow"
+            content.subtitle = "Deeplink use case"
+            content.body = "Click to navigate to Avatar"
+
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+            let request = UNNotificationRequest(identifier: "\(UUID())", content: content, trigger: trigger)
+
+            UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+        }
+    }
+
     @IBAction func about(_ sender: UIButton) {
         self.about()
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, link the related issues -->
This PR brings handling of deep links. The main Coordinator has now a navigate(to:) function that can be called form the AppDelegate to push a step in all the currently existing Flows. The Step will be received as usual in each Flow in their navigate(to:) function, so the navigation can happen as usual.

The RxFlowDemo has been adapted to include an example with a local notification.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
