### PR TITLE
CompositeStepper readyToEmitSteps improvement

### DIFF
--- a/RxFlow/Stepper.swift
+++ b/RxFlow/Stepper.swift
@@ -81,7 +81,7 @@ public class CompositeStepper: Stepper {
             .bind(to: self.steps)
             .disposed(by: self.disposeBag)
 
-        for stepper in innerSteppers {
+        self.innerSteppers.forEach { stepper in
             stepper.readyToEmitSteps()
         }
     }

--- a/RxFlow/Stepper.swift
+++ b/RxFlow/Stepper.swift
@@ -80,6 +80,10 @@ public class CompositeStepper: Stepper {
             .concat(nextSteps)
             .bind(to: self.steps)
             .disposed(by: self.disposeBag)
+
+        for stepper in innerSteppers {
+            stepper.readyToEmitSteps()
+        }
     }
 }
 

--- a/RxFlowTests/StepperTests.swift
+++ b/RxFlowTests/StepperTests.swift
@@ -28,10 +28,15 @@ final class StepperClass: Stepper {
     let steps = PublishRelay<Step>()
     let initialStep: Step
     let nextStep: Step
+    private(set) var madeReady = false
 
     init(with initialStep: Step, andNextStep nextStep: Step) {
         self.initialStep = initialStep
         self.nextStep = nextStep
+    }
+
+    func readyToEmitSteps() {
+        madeReady = true
     }
 
     func emitNextStep () {
@@ -119,6 +124,21 @@ final class StepperTests: XCTestCase {
         XCTAssertEqual(observer.events[0].value.element as? StepperTestsStep, StepperTestsStep.stepOne)
         XCTAssertEqual(observer.events[1].value.element as? StepperTestsStep, StepperTestsStep.stepTwo)
         XCTAssertEqual(observer.events[2].value.element as? StepperTestsStep, StepperTestsStep.stepThree)
+    }
+
+    func testCompositeStepperReadyToEmitSteps() {
+
+        // Given: a compositeStepper
+        let stepper1 = StepperClass(with: StepperTestsStep.stepOne, andNextStep: StepperTestsStep.stepTwo)
+        let stepper2 = StepperClass(with: StepperTestsStep.stepOne, andNextStep: StepperTestsStep.stepTwo)
+        let compositeStepper = CompositeStepper(steppers: [stepper1, stepper2])
+
+        // When: ready to emit steps
+        compositeStepper.readyToEmitSteps()
+
+        // Then: the composite steppers are made ready
+        XCTAssertTrue(stepper1.madeReady)
+        XCTAssertTrue(stepper2.madeReady)
     }
 
     func testCompositeStepper() {


### PR DESCRIPTION
## Description
When `CompositeStepper`'s `readyToEmitSteps()` method is called, each `Stepper` in `innerSteppers` has it's `readyToEmitSteps()` method called.
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] this PR is based on develop or a 'develop related' branch
- [X] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
