### PR TITLE
Changed retain policy on base to unowned on dismissed event.

### DIFF
--- a/RxFlow/Extensions/Reactive+UIViewController.swift
+++ b/RxFlow/Extensions/Reactive+UIViewController.swift
@@ -17,7 +17,7 @@ public extension Reactive where Base: UIViewController {
     /// Rx observable, triggered when the view is being dismissed
     var dismissed: ControlEvent<Bool> {
         let dismissedSource = self.sentMessage(#selector(Base.viewDidDisappear))
-            .filter { [base] _ in base.isBeingDismissed }
+            .filter { [unowned base] _ in base.isBeingDismissed }
             .map { _ in false }
 
         let movedToParentSource = self.sentMessage(#selector(Base.didMove))

--- a/RxFlow/Extensions/Reactive+UIViewController.swift
+++ b/RxFlow/Extensions/Reactive+UIViewController.swift
@@ -17,7 +17,7 @@ public extension Reactive where Base: UIViewController {
     /// Rx observable, triggered when the view is being dismissed
     var dismissed: ControlEvent<Bool> {
         let dismissedSource = self.sentMessage(#selector(Base.viewDidDisappear))
-            .filter { [unowned base] _ in base.isBeingDismissed }
+            .filter { [weak base] _ in base.isBeingDismissed ?? true }
             .map { _ in false }
 
         let movedToParentSource = self.sentMessage(#selector(Base.didMove))

--- a/RxFlow/Extensions/Reactive+UIViewController.swift
+++ b/RxFlow/Extensions/Reactive+UIViewController.swift
@@ -17,7 +17,7 @@ public extension Reactive where Base: UIViewController {
     /// Rx observable, triggered when the view is being dismissed
     var dismissed: ControlEvent<Bool> {
         let dismissedSource = self.sentMessage(#selector(Base.viewDidDisappear))
-            .filter { [weak base] _ in base.isBeingDismissed ?? true }
+            .filter { [weak base] _ in base?.isBeingDismissed ?? true }
             .map { _ in false }
 
         let movedToParentSource = self.sentMessage(#selector(Base.didMove))


### PR DESCRIPTION
Related to https://github.com/RxSwiftCommunity/RxFlow/issues/160

I changed the closure's retain policy on `base` to `unowned` so the `dismissed` event avoids retaining the base (UIViewController).

#trivial