### PR TITLE
fix: reentrancy issue with forwardToCurrentFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+** Version 2.12.4 **:
+
+- fix reentrancy issue with forwardToCurrentFlow
+
 ** Version 2.12.3 **:
 
 - fix "Unhandled files" warnings in the Package.swift file

--- a/RxFlow.podspec
+++ b/RxFlow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "RxFlow"
-  s.version = "2.12.3"
+  s.version = "2.12.4"
   s.swift_version = '5.4'
   s.summary = "RxFlow is a navigation framework for iOS applications, based on a Reactive Coordinator pattern."
 

--- a/RxFlow.xcodeproj/project.pbxproj
+++ b/RxFlow.xcodeproj/project.pbxproj
@@ -604,7 +604,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.3;
+				MARKETING_VERSION = 2.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.warpfactor.RxFlow;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -639,7 +639,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.3;
+				MARKETING_VERSION = 2.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.warpfactor.RxFlow;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/RxFlow/FlowCoordinator.swift
+++ b/RxFlow/FlowCoordinator.swift
@@ -128,7 +128,9 @@ public final class FlowCoordinator: NSObject {
     private func performSideEffects(with flowContributor: FlowContributor) {
         switch flowContributor {
         case let .forwardToCurrentFlow(step):
-            self.stepsRelay.accept(step)
+            DispatchQueue.main.async { [weak self] in
+                self?.stepsRelay.accept(step)
+            }
         case let .forwardToParentFlow(step):
             parentFlowCoordinator?.stepsRelay.accept(step)
         case .contribute:

--- a/RxFlowTests/FlowCoordinatorTests.swift
+++ b/RxFlowTests/FlowCoordinatorTests.swift
@@ -268,7 +268,7 @@ final class FlowCoordinatorTests: XCTestCase {
 
         // Then: Steps from .multiple FlowContributors are triggered.toArray()
         let actualSteps = try? testFlow.recordedSteps.take(3).toBlocking().toArray()
-        XCTAssertEqual(actualSteps, [.multiple, .one, .two])
+        XCTAssertEqual(actualSteps, [.multiple, .two, .one])
     }
 
     func testStepHasBeenFilteredBeforeNavigateForAFlowStepper() {


### PR DESCRIPTION
## Description
fix reentrancy issue with forwardToCurrentFlow

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [x] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
