### PR TITLE
fix : doesn't not apply allowsStepWhenDismissed property of new stepper

### DIFF
--- a/RxFlow/FlowCoordinator.swift
+++ b/RxFlow/FlowCoordinator.swift
@@ -96,7 +96,7 @@ public final class FlowCoordinator: NSObject {
             // the FlowContributor is not related to a new Flow but to a Presentable/Stepper
             // this new Stepper will contribute to the current Flow.
             .flatMap { [weak self] in
-                self?.steps(from: $0, within: flow, allowStepWhenDismissed: allowStepWhenDismissed) ?? Signal.empty()
+                self?.steps(from: $0, within: flow, allowStepWhenDismissed: $0.allowStepWhenDismissed) ?? Signal.empty()
             }
             .asObservable()
             .take(until: allowStepWhenDismissed ? .empty() : flow.rxDismissed.asObservable())

--- a/RxFlowDemo/RxFlowDemo/Flows/SettingsFlow.swift
+++ b/RxFlowDemo/RxFlowDemo/Flows/SettingsFlow.swift
@@ -89,7 +89,7 @@ class SettingsFlow: Flow {
 
         return .multiple(flowContributors: [
             .contribute(withNext: settingsListViewController),
-            .contribute(withNext: settingsLoginViewController),
+            .contribute(withNextPresentable: settingsLoginViewController, withNextStepper: settingsLoginViewController, allowStepWhenDismissed: true),
             .forwardToCurrentFlow(withStep: DemoStep.alert("Demo of multiple Flow Contributor"))
         ])
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, link the related issues -->

When I run DemoApp, I found a bug which is UISplitViewController detailVC's steps doesn't no be handled properly after first appear
- Reproduce 
 1. Login Screen appear after tap setting icon button, 
 2. Then tap proceed button 
 3. But nothing happend

https://user-images.githubusercontent.com/24935280/138263572-7657022a-876c-4e3e-9111-9b70083de283.mov

I think main reason of this bug is that that doesn't not apply allowsStepWhenDismissed property of new stepper.
So I modify it. Also demo code.

- Result

https://user-images.githubusercontent.com/24935280/138264551-91757453-06e8-4c84-8513-442f85da1389.mov

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [x] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
