### PR TITLE
Fix: Adapt method is disposed before being completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+** Version 2.12.5 **:
+
+- fix adapt method is disposed before being completed
+
 ** Version 2.12.4 **:
 
 - fix reentrancy issue with forwardToCurrentFlow

--- a/RxFlow.podspec
+++ b/RxFlow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "RxFlow"
-  s.version = "2.12.4"
+  s.version = "2.12.5"
   s.swift_version = '5.4'
   s.summary = "RxFlow is a navigation framework for iOS applications, based on a Reactive Coordinator pattern."
 

--- a/RxFlow.xcodeproj/project.pbxproj
+++ b/RxFlow.xcodeproj/project.pbxproj
@@ -604,7 +604,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.4;
+				MARKETING_VERSION = 2.12.5;
 				PRODUCT_BUNDLE_IDENTIFIER = io.warpfactor.RxFlow;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -639,7 +639,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.4;
+				MARKETING_VERSION = 2.12.5;
 				PRODUCT_BUNDLE_IDENTIFIER = io.warpfactor.RxFlow;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/RxFlow/FlowCoordinator.swift
+++ b/RxFlow/FlowCoordinator.swift
@@ -52,7 +52,7 @@ public final class FlowCoordinator: NSObject {
                 self?.parentFlowCoordinator?.childFlowCoordinators.removeValue(forKey: self?.identifier ?? "")
             })
             .asSignal(onErrorJustReturn: NoneStep())
-            .flatMapLatest { flow.adapt(step: $0).asSignal(onErrorJustReturn: NoneStep()) }
+            .flatMap { flow.adapt(step: $0).asSignal(onErrorJustReturn: NoneStep()) }
             .do(onNext: { [weak self] in self?.willNavigateRelay.accept((flow, $0)) })
             .map { return (flowContributors: flow.navigate(to: $0), step: $0) }
             .do(onNext: { [weak self] in self?.didNavigateRelay.accept((flow, $0.step)) })


### PR DESCRIPTION
## Description
replace .flatMapLatest with .flatMap to avoid adapt to be disposed before being completed
related issue #183 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
