### PR TITLE
refactor :: unnecessary weak references

### DIFF
--- a/RxFlow/FlowCoordinator.swift
+++ b/RxFlow/FlowCoordinator.swift
@@ -128,8 +128,8 @@ public final class FlowCoordinator: NSObject {
     private func performSideEffects(with flowContributor: FlowContributor) {
         switch flowContributor {
         case let .forwardToCurrentFlow(step):
-            DispatchQueue.main.async { [weak self] in
-                self?.stepsRelay.accept(step)
+            DispatchQueue.main.async {
+                self.stepsRelay.accept(step)
             }
         case let .forwardToParentFlow(step):
             parentFlowCoordinator?.stepsRelay.accept(step)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, link the related issues -->

```swift
DispatchQueue.main.async { [weak self] in
    self?.stepsRelay.accept(step)
}
```
This code does not cause retain cycle. However, [FlowCoordinator#L131-L133](https://github.com/RxSwiftCommunity/RxFlow/blob/main/RxFlow/FlowCoordinator.swift#L131-L133) is written like that.

So I refactored these unnecessary wake references.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] refactoring unnecessary weak references

#trivial