### PR TITLE
Presentable `allowStepWhenDismissed` is ignored and overridden with parent flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ** *Unreleased* **:
+- fix: presentable `allowStepWhenDismissed` now are not ignored and not overridden by parent flow
 - fix: `displayed` and `rxVisible` now do not assume UIViewController starts not visible
 
 ** Version 2.13.0 **:


### PR DESCRIPTION
## Description
Recently, I noticed that presentables (not flows) utilises [parent flow `allowStepWhenDismissed`](https://github.com/RxSwiftCommunity/RxFlow/blob/367eb93116ab4868658f128b000d3ab248abc96e/RxFlow/FlowCoordinator.swift#L186) instead of its own property. 
It may lead to a scenario where stepper and presentable are unexpectedly held in the memory until the parent flow is released.
I doubt if it is an intended behaviour.

The PR fixes it.

## Checklist
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
