### PR TITLE
Fix: Flow is not released when embedded in UINavigationController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ** *Unreleased* **:
+- fix: flow is not released when embedded in UINavigationController
 - fix: `displayed` and `rxVisible` now do not assume UIViewController starts not visible
 
 ** Version 2.13.0 **:

--- a/RxFlow/Extensions/Reactive+UIViewController.swift
+++ b/RxFlow/Extensions/Reactive+UIViewController.swift
@@ -17,7 +17,9 @@ public extension Reactive where Base: UIViewController {
     /// Rx observable, triggered when the view is being dismissed
     var dismissed: ControlEvent<Bool> {
         let dismissedSource = self.sentMessage(#selector(Base.viewDidDisappear))
-            .filter { [base] _ in base.isBeingDismissed }
+            .filter { [base] _ in
+                base.isBeingDismissed || base.navigationController?.isBeingDismissed == true
+            }
             .map { _ in false }
 
         let movedToParentSource = self.sentMessage(#selector(Base.didMove))


### PR DESCRIPTION
## Description
The PR fixes [#197](https://github.com/RxSwiftCommunity/RxFlow/issues/197)
By updating `rxDismissed` for `UIViewController` to emit an event when `UIViewController` is dismissed along with presenting `UINavigationController`.

I could not find a way to replicate dismissal in `XCUnitTests`, that is why there are no tests added.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on develop or a 'develop related' branch
- [x] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
